### PR TITLE
리프레시 토큰 업데이트 활성화

### DIFF
--- a/src/main/java/com/github/devsns/domain/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/github/devsns/domain/auth/handler/LoginSuccessHandler.java
@@ -35,18 +35,18 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken); // 응답 헤더에 AccessToken, RefreshToken 실어서 응답
 
-        userRepository.findByEmail(email)
-                .ifPresent(user -> {
-                    user.updateRefreshToken(refreshToken);
-                    userRepository.saveAndFlush(user);
-                });
-
         UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(
                 () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND.getMessage(), ErrorCode.USER_EMAIL_NOT_FOUND)
         );
+
+        userEntity.updateRefreshToken(refreshToken);
+        userRepository.saveAndFlush(userEntity);
+
+
         log.info("로그인에 성공하였습니다. 이메일 : {}", email);
         log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
         log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
+        log.info("refreshToken = {}", refreshToken);
     }
 
     private String extractUsername(Authentication authentication) {

--- a/src/main/java/com/github/devsns/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/github/devsns/global/jwt/filter/JwtAuthenticationFilter.java
@@ -35,7 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         이때, return을 통해 다음 필터를 호출하고 현재 필터의 진행을 막는다.
          */
         if (request.getRequestURI().equals(NO_CHECK_URL)) {
-            log.info(request.getRequestURI());
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
기존의 리프레시 토큰이 유저 엔티티에 들어갈때 임시로 만들다보니 그냥 업데이트가 안된 현상이 있어서

 유저가 LoginSuccessHandler에서 로그인할 때 마다 리프레시 토큰을 업데이트해주는 걸로 변경했습니다.